### PR TITLE
[#615] fix sanity check error

### DIFF
--- a/lib/messages/execute.py
+++ b/lib/messages/execute.py
@@ -142,6 +142,8 @@ def parse (db, tx, message):
         tx_obj = Transaction(tx, contract_id, gasprice, startgas, value, payload)
         block_obj = blocks.Block(db, tx['block_hash'])
         success, output, gas_remained = processblock.apply_transaction(db, tx_obj, block_obj)
+        if not success and output == '':
+            status = 'out of gas'
         gas_cost = gasprice * (startgas - gas_remained) # different definition from pyethereum’s
 
     except exceptions.UnpackError as e:

--- a/lib/messages/scriptlib/processblock.py
+++ b/lib/messages/scriptlib/processblock.py
@@ -170,7 +170,7 @@ def apply_transaction(db, tx, block):
 
 
     if not result:  # 0 = OOG failure in both cases
-        # pblogger.log('TX FAILED', reason='out of gas', startgas=tx.startgas, gas_remained=gas_remained)
+        pblogger.log('TX FAILED', reason='out of gas', startgas=tx.startgas, gas_remained=gas_remained)
         output = OUT_OF_GAS
     else:
         pblogger.log('TX SUCCESS')

--- a/lib/util.py
+++ b/lib/util.py
@@ -433,9 +433,14 @@ def holders(db, asset):
             holders.append({'address': rps_match['tx0_address'], 'address_quantity': rps_match['wager'], 'escrow': rps_match['id']})
             holders.append({'address': rps_match['tx1_address'], 'address_quantity': rps_match['wager'], 'escrow': rps_match['id']})
 
-        cursor.execute('''SELECT * FROM executions WHERE status = ?''', ('valid',))
+        cursor.execute('''SELECT * FROM executions WHERE status IN (?,?)''', ('valid','out of gas'))
         for execution in list(cursor):
             holders.append({'address': execution['source'], 'address_quantity': execution['gas_cost'], 'escrow': None})
+
+        # XCP escrowed for not finished executions
+        cursor.execute('''SELECT * FROM executions WHERE status = ?''', ('out of gas',))
+        for execution in list(cursor):
+            holders.append({'address': execution['source'], 'address_quantity': execution['gas_remained'], 'escrow': execution['contract_id']})
 
     cursor.close()
     return holders


### PR DESCRIPTION
- Fix `executions` status when contract execution failed
- In XCP holders calculation, include `gas_remained` and `gas_cost` for executions with status equal to `out of gas`