### PR TITLE
Use standard folders to store logs and database

### DIFF
--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -81,22 +81,10 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
                 force=False, verbose=False,
                 broadcast_tx_mainnet=None):
 
-    # Database
-    if database_file:
-        config.DATABASE = database_file
-    else:
-        raise ConfigurationError("Please specific a valid sqlite3 database file path")
-
-    # Logs
-    if log_file:
-        config.LOG = log_file
-    else:
-        config.LOG = None
-
-    if api_log_file:
-        config.API_LOG = api_log_file
-    else:
-        config.API_LOG = None
+     # Data directory
+    config.DATA_DIR = appdirs.user_data_dir(appauthor=config.XCP_NAME, appname=config.XCP_NAME.lower(), roaming=True)
+    if not os.path.isdir(config.DATA_DIR):
+        os.makedirs(config.DATA_DIR)
 
     # testnet
     if testnet:
@@ -109,6 +97,37 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
         config.TESTCOIN = testcoin
     else:
         config.TESTCOIN = False
+
+    network = ''
+    if config.TESTNET:
+        network += '.testnet'
+    if config.TESTCOIN:
+        network += '.testcoin'
+
+    # Database
+    if database_file:
+        config.DATABASE = database_file
+    else:
+        filename = '{}.{}{}.db'.format(config.XCP_NAME.lower(), config.VERSION_MAJOR, network)
+        config.DATABASE = os.path.join(config.DATA_DIR, filename)
+
+    # Log directory
+    config.LOG_DIR = appdirs.user_log_dir(appauthor=config.XCP_NAME, appname=config.XCP_NAME.lower())
+    if not os.path.isdir(config.LOG_DIR):
+        os.makedirs(config.LOG_DIR)
+
+    # Log
+    if log_file:
+        config.LOG = log_file
+    else:
+        filename = '{}{}.log'.format(config.XCP_NAME.lower(), network)
+        config.LOG = os.path.join(config.LOG_DIR, filename)
+
+    if api_log_file:
+        config.API_LOG = api_log_file
+    else:
+        filename = '{}{}.api.log'.format(config.XCP_NAME.lower(), network)
+        config.API_LOG = os.path.join(config.LOG_DIR, filename)
 
     ##############
     # THINGS WE CONNECT TO


### PR DESCRIPTION
- make optional `database_file`, `log_file` and `api_log_file` args
- `appdirs.user_data_dir()` as default folder to store the database
- `appdirs.user_log_dir()` as default folder to store log files