### PR TITLE
Default to Using `OP_RETURN` Encoding When Possible

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 	* automatically spend 1‐of‐`N` multisig outputs
 	* remove `get_asset_info(assets)` method from the API
 	* replace `get_xcp_supply()` method from the API by `get_supply(asset)`
+	* default to using `opreturn` encoding when possible
 * v9.49.4 (2014-02-05)
 	* reconceived this package as a libary
 	* moved CLI to new repository: `counterparty-cli`

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -350,7 +350,7 @@ def construct (db, tx_info, encoding='auto',
     if data:
         if encoding == 'auto':
             if len(data) <= config.OP_RETURN_MAX_SIZE:
-                encoding = 'multisig'   # BTCGuild isn’t mining `OP_RETURN`?!
+                encoding = 'opreturn'
             else:
                 encoding = 'multisig'
         elif encoding not in ('pubkeyhash', 'multisig', 'opreturn'):


### PR DESCRIPTION
80-byte `OP_RETURN` support is coming as well: #690 