### PR TITLE
[#566] [#687] HTTP REST API

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@
 	* automatically spend 1‐of‐`N` multisig outputs
 	* remove `get_asset_info(assets)` method from the API
 	* replace `get_xcp_supply()` method from the API by `get_supply(asset)`
+	* added HTTP REST API
+	* authentication on JSON-RPC API is off by default
+	* RPC password is not mandatory now
 * v9.49.4 (2014-02-05)
 	* reconceived this package as a libary
 	* moved CLI to new repository: `counterparty-cli`

--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -210,6 +210,9 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
     else:
         config.RPC_HOST = 'localhost'
 
+    # The web root directory for API calls, eg. localhost:14000/rpc/
+    config.RPC_WEBROOT = '/rpc/'
+
     # counterpartyd API RPC port
     if rpc_port:
         config.RPC_PORT = rpc_port
@@ -240,10 +243,9 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
     #  counterpartyd API RPC password
     if rpc_password:
         config.RPC_PASSWORD = rpc_password
+        config.RPC = 'http://' + urlencode(config.RPC_USER) + ':' + urlencode(config.RPC_PASSWORD) + '@' + config.RPC_HOST + ':' + str(config.RPC_PORT) + config.RPC_WEBROOT
     else:
-        raise ConfigurationError('RPC password not set. (Use configuration file or --rpc-password=PASSWORD)')
-
-    config.RPC = 'http://' + urlencode(config.RPC_USER) + ':' + urlencode(config.RPC_PASSWORD) + '@' + config.RPC_HOST + ':' + str(config.RPC_PORT)
+        config.RPC = 'http://' + config.RPC_HOST + ':' + str(config.RPC_PORT) + config.RPC_WEBROOT
 
     # RPC CORS
     if rpc_no_allow_cors:

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -123,7 +123,7 @@ UNITTEST_VECTOR = {
             'in': (ADDR[2],),
             'out': (0)
         }],
-        # Test match by calling parse. Add all skipping modes
+        # TODO: Test match by calling parse. Add all skipping modes
         'match': [{
             'in': ({'tx_index': 99999999},),
             'out': None
@@ -132,7 +132,7 @@ UNITTEST_VECTOR = {
             'out': None
         }],
         # Testing expiration of normal bets is impossible - either the bet is expired automatically with expiry < 310500 or
-        # with expire > 310500 insert fails with FOREING KEY error on block_index (which doesn't exist). With expiry 310500 nothing happens.
+        # with expire > 310500 insert fails with FOREIGN KEY error on block_index (which doesn't exist). With expiry 310500 nothing happens.
         # Testing bet_match expirations is impossible too, since if you add a bet_match with 'pending' status to the fixtures, it raises a ConsensusError in blocks.parse_block.
         # 'expire': [{
         #     'in': (DP['default_block'] - 1, 5388000200,),

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,8 @@ required_packages = [
     'tendo',
     'pysha3',
     'colorlog',
-    'python-bitcoinlib'
+    'python-bitcoinlib',
+    'xmltodict'
 ]
 
 setup_options = {


### PR DESCRIPTION
Solves #566 and #687.

- All API calls go through a single handler now.
- New GET /rest/ call as an interface to get_rows database queries.
- New POST /rest/ call as an interface to compose_transaction calls.
- JSON-RPC doesn't listen on / anymore (that access route not documented anyway).
- RPC_PASSWORD config setting is no longer mandatory.
- Adds xmltodict requirement.

The API is documented here for now:
http://docs.counterpartylib.apiary.io/#