### PR TITLE
Check if `parsed_source` is not a 1 of X multisig address

### DIFF
--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -481,7 +481,7 @@ def construct (db, tx_info, encoding='auto',
     # Check desired info against parsed info.
     desired = (desired_source, desired_destination, desired_data)
     parsed = (parsed_source, parsed_destination, parsed_data)
-    if desired != parsed:
+    if (desired_destination, desired_data) != (parsed_destination, parsed_data) or desired_source not in parsed_source:
         raise exceptions.TransactionError('Constructed transaction does not parse correctly: {} ≠ {}'.format(desired, parsed))
 
     return unsigned_tx_hex


### PR DESCRIPTION
Inelegant but quick and fast way to fix #721 : because the new `is_scriptpubkey_spendable()`, `parsed_source` can be a 1 of X multisig address.
Note: maybe there is several cases to get the `Constructed transaction does not parse correctly` error, but this patch fixes at least one of them.