### PR TITLE
fixes bug with integer binding values causing an exception

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -89,7 +89,7 @@ def db_query(db, statement, bindings=(), callback=None, **callback_args):
     # Sanitize.
     forbidden_words = ['pragma', 'attach', 'database', 'begin', 'transaction']
     for word in forbidden_words:
-        if word in statement.lower() or any([word in binding.lower() for binding in bindings]):
+        if word in statement.lower() or any([word in str(binding).lower() for binding in bindings]):
             raise APIError("Forbidden word in query: '{}'.".format(word))
 
     if hasattr(callback, '__call__'):


### PR DESCRIPTION
For instance, when doing a counterblock sync against counterpartyd develop, I have a statement like:

SELECT * FROM orders WHERE (give_remaining > ? AND get_remaining > ? AND fee_required_remaining >= ? AND fee_provided_remaining >= ?) AND (status == ? AND ((give_asset == ? AND expire_index > ?) OR give_asset != ?)) LIMIT 1000

the bindings supplied are: (0, 0, 0, 0, 'open', 'BTC', 329066, 'BTC')

This fix avoids:
```
Traceback (most recent call last):
  File "/home/xcp/federatednode_build/env/lib/python3.4/site-packages/jsonrpc/manager.py", line 104, in _get_responses
    result = method(*request.args, **request.kwargs)
  File "/home/xcp/federatednode_build/env/lib/python3.4/site-packages/counterpartylib/lib/api.py", line 388, in get_method
    return get_rows(db, table=table, **kwargs)
  File "/home/xcp/federatednode_build/env/lib/python3.4/site-packages/counterpartylib/lib/api.py", line 238, in get_rows
    return db_query(db, statement, tuple(bindings))
  File "/home/xcp/federatednode_build/env/lib/python3.4/site-packages/counterpartylib/lib/api.py", line 93, in db_query
    if word in statement.lower() or any([word in binding.lower() for binding in bindings]):
  File "/home/xcp/federatednode_build/env/lib/python3.4/site-packages/counterpartylib/lib/api.py", line 93, in <listcomp>
    if word in statement.lower() or any([word in binding.lower() for binding in bindings]):
AttributeError: 'int' object has no attribute 'lower'
```