### PR TITLE
Faster Rollbacks with Savepoints

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 	* Use batch queries to get transactions hex from backend
 	* optimise asset conservation check
 	* code reorganisation
+	* faster rollbacks
 * v9.51.0 (2015-04-01)
 	* check for null data chunks (protocol change: 352000)
 	* disable rock‐paper‐scissors (protocol change: 352000)


### PR DESCRIPTION
A little kludgy, but simple enough to be reliable and maintainable, I think.

Not sure if this will be a memory/storage hog. All savepoints are currently released 1) after every reorg. and 2) every `N = 100` blocks.

This will make reorgs. instantaneous most of the time. Reorgs. immediately following the clearing of all savepoints will work as they always have before.